### PR TITLE
Replaces comma in link to `cldr` in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cldr Utils
 
-Utility functions extracted from [cldr](https://github,com/kipcole9/cldr)
+Utility functions extracted from [cldr](https://github.com/kipcole9/cldr)
 
 * Map functions for deep mapping, deep merging, transforming keys
 * Math functions including `mod/2` that works on floored division


### PR DESCRIPTION
The link to `cldr` in the README did not work because of a tiny typographical error.

Now it does :slightly_smiling_face: .