### PR TITLE
:persistent_term.get/2 may not be available

### DIFF
--- a/lib/cldr/utils/macros.ex
+++ b/lib/cldr/utils/macros.ex
@@ -29,9 +29,22 @@ defmodule Cldr.Macros do
     quote do
       require Logger
 
-      if :persistent_term.get({unquote(caller), unquote(key)}, true) do
+      ck = {unquote(caller), unquote(key)}
+
+      missing? =
+        if function_exported?(:persistent_term, :get, 2) do
+          :persistent_term.get(ck, true)
+        else
+          try do
+            :persistent_term.get(ck)
+          rescue
+            ArgumentError -> true
+          end
+        end
+
+      if missing? do
         Logger.unquote(level)(unquote(message))
-        :persistent_term.put({unquote(caller), unquote(key)}, nil)
+        :persistent_term.put(ck, nil)
       end
     end
   end

--- a/lib/cldr/utils/macros.ex
+++ b/lib/cldr/utils/macros.ex
@@ -33,7 +33,8 @@ defmodule Cldr.Macros do
 
       missing? =
         if function_exported?(:persistent_term, :get, 2) do
-          :persistent_term.get(ck, true)
+          apply(:persistent_term, :get, [ck, true])
+          # :persistent_term.get(ck, true)
         else
           try do
             :persistent_term.get(ck)


### PR DESCRIPTION
I believe that :persistent_term.get/2 was added with Erlang 22. The version of
Erlang 21 that I’m currently running only exports :persistent_term.get/1 and
:persistent_term.get/0

This is a minimal change to ensure that we build without warnings (which
become errors on my side) during number format compilation.