### PR TITLE
Fix unused variable warning

### DIFF
--- a/lib/cldr/utils/helpers.ex
+++ b/lib/cldr/utils/helpers.ex
@@ -48,7 +48,7 @@ defmodule Cldr.Helpers do
       end
 
       @doc false
-      def put_term(key, value) do
+      def put_term(_key, value) do
         value
       end
   end


### PR DESCRIPTION
This PR fixes the warning below.

```
warning: variable "key" is unused (if the variable is not meant to be used, prefix it with an underscore)
  lib/cldr/utils/helpers.ex:51
```