### PR TITLE
Support runtime cacert config

### DIFF
--- a/lib/cldr/http/http.ex
+++ b/lib/cldr/http/http.ex
@@ -327,73 +327,81 @@ defmodule Cldr.Http do
     end
   end
 
-  @certificate_locations [
+  @static_certificate_locations [
+    # Debian/Ubuntu/Gentoo etc.
+    "/etc/ssl/certs/ca-certificates.crt",
+
+    # Fedora/RHEL 6
+    "/etc/pki/tls/certs/ca-bundle.crt",
+
+    # OpenSUSE
+    "/etc/ssl/ca-bundle.pem",
+
+    # OpenELEC
+    "/etc/pki/tls/cacert.pem",
+
+    # CentOS/RHEL 7
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+
+    # Open SSL on MacOS
+    "/usr/local/etc/openssl/cert.pem",
+
+    # MacOS & Alpine Linux
+    "/etc/ssl/cert.pem"
+  ]
+
+  defp dymanic_certificate_locations do
+    [
       # Configured cacertfile
-      Application.compile_env(:ex_cldr, :cacertfile),
+      Application.get_env(:ex_cldr, :cacertfile),
 
       # Populated if hex package CAStore is configured
       if(Code.ensure_loaded?(CAStore), do: CAStore.file_path()),
 
       # Populated if hex package certfi is configured
-      if(Code.ensure_loaded?(:certifi), do: :certifi.cacertfile() |> List.to_string),
+      if(Code.ensure_loaded?(:certifi), do: :certifi.cacertfile() |> List.to_string())
+    ]
+    |> Enum.reject(&is_nil/1)
+  end
 
-      # Debian/Ubuntu/Gentoo etc.
-      "/etc/ssl/certs/ca-certificates.crt",
-
-      # Fedora/RHEL 6
-      "/etc/pki/tls/certs/ca-bundle.crt",
-
-      # OpenSUSE
-      "/etc/ssl/ca-bundle.pem",
-
-      # OpenELEC
-      "/etc/pki/tls/cacert.pem",
-
-      # CentOS/RHEL 7
-      "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
-
-      # Open SSL on MacOS
-      "/usr/local/etc/openssl/cert.pem",
-
-      # MacOS & Alpine Linux
-      "/etc/ssl/cert.pem"
-  ]
-  |> Enum.reject(&is_nil/1)
+  def certificate_locations() do
+    dymanic_certificate_locations() ++ @static_certificate_locations
+  end
 
   @doc false
   defp certificate_store do
-    @certificate_locations
+    certificate_locations()
     |> Enum.find(&File.exists?/1)
     |> raise_if_no_cacertfile!
-    |> :erlang.binary_to_list
+    |> :erlang.binary_to_list()
   end
 
   defp raise_if_no_cacertfile!(nil) do
     raise RuntimeError, """
-      No certificate trust store was found.
-      Tried looking for: #{inspect @certificate_locations}
+    No certificate trust store was found.
+    Tried looking for: #{inspect(certificate_locations())}
 
-      A certificate trust store is required in
-      order to download locales for your configuration.
+    A certificate trust store is required in
+    order to download locales for your configuration.
 
-      Since ex_cldr could not detect a system
-      installed certificate trust store one of the
-      following actions may be taken:
+    Since ex_cldr could not detect a system
+    installed certificate trust store one of the
+    following actions may be taken:
 
-      1. Install the hex package `castore`. It will
-         be automatically detected after recompilation.
+    1. Install the hex package `castore`. It will
+       be automatically detected after recompilation.
 
-      2. Install the hex package `certifi`. It will
-         be automatically detected after recomilation.
+    2. Install the hex package `certifi`. It will
+       be automatically detected after recomilation.
 
-      3. Specify the location of a certificate trust store
-         by configuring it in `config.exs`:
+    3. Specify the location of a certificate trust store
+       by configuring it in `config.exs`:
 
-         config :ex_cldr,
-           cacertfile: "/path/to/cacertfile",
-           ...
+       config :ex_cldr,
+         cacertfile: "/path/to/cacertfile",
+         ...
 
-      """
+    """
   end
 
   defp raise_if_no_cacertfile!(file) do


### PR DESCRIPTION
While using the `ex_money` library, I ran into an issue where cacert trust store config was failing, and after some digging, I found that it was because how `cldr_utils` configures the supported cacert paths at compile time.

As the dynamic paths are expanded while in a module constant, everything is baked in at compile time, which makes it impossible for people to use `runtime.ex` for configuration, and causes issues when people compile their application in one environment but deploy to a slightly different environment (eg. build and compile in one docker container, and then copy the distribution to another image with a different structure).

This PR also applies best practices as suggested by https://hexdocs.pm/elixir/library-guidelines.html#avoid-application-configuration

> If you must use configuration, then prefer runtime configuration instead of compile-time configuration.